### PR TITLE
Fix option description format

### DIFF
--- a/lib/thor/zsh_completion/generator.rb
+++ b/lib/thor/zsh_completion/generator.rb
@@ -90,7 +90,7 @@ class Thor
 
       def option_metadata(option)
         { names: ["--#{option.name}"] + option.aliases.map{|a| "-#{a}" },
-          description: option.description,
+          description: "\"[#{option.description}]\"",
         }
       end
     end

--- a/spec/thor/zsh_completion/generator_spec.rb
+++ b/spec/thor/zsh_completion/generator_spec.rb
@@ -22,7 +22,7 @@ describe Thor::ZshCompletion::Generator do
     end
 
     main = Class.new(Thor) do
-      class_option :global, description: "Global option"
+      class_option :global, desc: "Global option"
 
       desc "foo", "Description of foo"
       def foo
@@ -41,4 +41,3 @@ describe Thor::ZshCompletion::Generator do
 
   it { should eq expected }
 end
-

--- a/spec/thor/zsh_completion/generator_spec.zsh
+++ b/spec/thor/zsh_completion/generator_spec.zsh
@@ -45,7 +45,7 @@ __generator_spec() {
 
 __generator_spec_foo() {
   _arguments \
-    {--global} \
+    {--global}"[Global option]" \
     '*: :->rest'
 
   case $state in
@@ -62,7 +62,7 @@ __generator_spec_nest1() {
   case $CURRENT in
     $DEPTH)
       _arguments \
-        {--global} \
+        {--global}"[Global option]" \
         '*: :->subcommands'
 
       case $state in


### PR DESCRIPTION
## Point1 - :description is invalid option.
```ruby
main = Class.new(Thor) do
  # => description is invalid
  class_option :global, description: "Global option"

  desc "foo", "Description of foo"
  def foo
    p options
    puts "foo"
  end

  desc "nest1", "Description of nest1"
  subcommand "nest1", nest1
end
```

>:desc — A description for the option. When printing out full usage for a command using cli help hello, this description will appear next to the option.

[Method-Options - Wiki - Thor](https://github.com/erikhuda/thor/wiki/Method-Options)

So, thor ignores `:description` .

Correct option is `:desc`

```ruby
# class_option :global, description: "Global option"
class_option :global, desc: "Global option"
```

## Point2 - option format
|--|format|example|doc url|
|---|---|---|:---:|
|zsh-completions doc|-OPT"[DESCRIPTION]"|`{--type, -t}[type of hogeh]`|[zsh doc](https://github.com/zsh-users/zsh-completions/blob/master/zsh-completions-howto.org#writing-completion-functions-using-_arguments)|
|current implementation|-OPT DESCRIPTION|`{--type, -t}type of hogeh`|--|
