### PR TITLE
Added support for dashed commands and Thor.map

### DIFF
--- a/lib/thor/zsh_completion/generator.rb
+++ b/lib/thor/zsh_completion/generator.rb
@@ -45,6 +45,7 @@ class Thor
 
         main = {
           name: "__#{name}",
+          safe_name: secure_function_name("__#{name}"),
           description: nil,
           options: [],
           subcommands: subcommand_metadata(thor)
@@ -55,12 +56,17 @@ class Thor
       end
 
       private
+
+      def secure_function_name(str)
+        str.gsub(/[^a-z0-9_]/, '_u_')
+      end
+
       def render_subcommand_function(subcommand, options = {})
         prefix = options[:prefix] || []
 
         source = []
 
-        prefix = (prefix + [subcommand[:name]])
+        prefix = (prefix + [subcommand[:safe_name]])
         function_name = prefix.join("_")
         depth = prefix.size + 1
 
@@ -78,7 +84,9 @@ class Thor
           else
             subcommands = []
           end
-          { name: command.name.gsub("_", "-"),
+          cmd_name = command.name.gsub("_", "-")
+          { name: cmd_name,
+            safe_name: secure_function_name(cmd_name),
             usage: command.usage,
             description: command.description,
             options: thor.class_options.map{|_, o| option_metadata(o) } +

--- a/lib/thor/zsh_completion/generator.rb
+++ b/lib/thor/zsh_completion/generator.rb
@@ -51,6 +51,8 @@ class Thor
           subcommands: subcommand_metadata(thor)
         }
 
+        @rendered_functions = {}
+
         erb = File.read("#{File.dirname(__FILE__)}/template/main.erb")
         ERB.new(erb, nil, "-").result(binding)
       end
@@ -70,7 +72,12 @@ class Thor
         function_name = prefix.join("_")
         depth = prefix.size + 1
 
+        return '' if @rendered_functions[function_name]
+
         source << SUBCOMMAND_FUNCTION_TEMPLATE.result(binding)
+
+        @rendered_functions[function_name] = true
+
         subcommand[:subcommands].each do |subcommand|
           source << render_subcommand_function(subcommand, prefix: prefix)
         end
@@ -78,22 +85,33 @@ class Thor
       end
 
       def subcommand_metadata(thor)
-        thor.tasks.map do |(name, command)|
-          if subcommand_class = thor.subcommand_classes[name]
-            subcommands = subcommand_metadata(subcommand_class)
-          else
-            subcommands = []
-          end
-          cmd_name = command.name.gsub("_", "-")
-          { name: cmd_name,
-            safe_name: secure_function_name(cmd_name),
-            usage: command.usage,
-            description: command.description,
-            options: thor.class_options.map{|_, o| option_metadata(o) } +
-                     command.options.map{|(_, o)| option_metadata(o) },
-            subcommands: subcommands
-          }
+        result = []
+        thor.tasks.each do |(name, command)|
+          result << gen_command_information(thor, name, command)
         end
+        thor.map.each do |_alias, name|
+          next if ['-?', '-D', '--help'].include?(_alias)
+          command = thor.tasks[name.to_s.gsub('-', '_')] or next
+          result << gen_command_information(thor, _alias, command)
+        end
+        result.uniq! { |info| info[:name] }
+        result
+      end
+
+      def gen_command_information(thor, name, command)
+        if subcommand_class = thor.subcommand_classes[name]
+          subcommands = subcommand_metadata(subcommand_class)
+        else
+          subcommands = []
+        end
+        { name: name.gsub("_", "-"),
+          safe_name: secure_function_name(command.name),
+          usage: command.usage,
+          description: command.description,
+          options: thor.class_options.map{|_, o| option_metadata(o) } +
+                   command.options.map{|(_, o)| option_metadata(o) },
+          subcommands: subcommands
+        }
       end
 
       def option_metadata(option)

--- a/lib/thor/zsh_completion/template/subcommand_function.erb
+++ b/lib/thor/zsh_completion/template/subcommand_function.erb
@@ -25,7 +25,7 @@
       case $words[$DEPTH] in
         <%- subcommand[:subcommands].each do |subcommand| -%>
         <%= subcommand[:name] %>)
-          <%= function_name %>_<%= subcommand[:name] %>
+          <%= function_name %>_<%= subcommand[:safe_name] %>
           ;;
         <%- end -%>
         *)

--- a/spec/thor/zsh_completion/generator_spec.rb
+++ b/spec/thor/zsh_completion/generator_spec.rb
@@ -8,6 +8,13 @@ describe Thor::ZshCompletion::Generator do
         p options
         puts "baz"
       end
+      # map 'b' => 'baz'
+
+      desc "foo-bar", "Dashed command"
+      def foo_bar
+        p options
+        puts "foo-bar"
+      end
     end
 
     nest1 = Class.new(Thor) do

--- a/spec/thor/zsh_completion/generator_spec.rb
+++ b/spec/thor/zsh_completion/generator_spec.rb
@@ -8,7 +8,7 @@ describe Thor::ZshCompletion::Generator do
         p options
         puts "baz"
       end
-      # map 'b' => 'baz'
+      map 'b' => 'baz'
 
       desc "foo-bar", "Dashed command"
       def foo_bar

--- a/spec/thor/zsh_completion/generator_spec.zsh
+++ b/spec/thor/zsh_completion/generator_spec.zsh
@@ -73,6 +73,7 @@ __generator_spec_nest1() {
             'bar[Description of bar]' \
             'nest2[Description of nest2]' \
             'help[Describe subcommands or one specific subcommand]' \
+            '-h[Describe subcommands or one specific subcommand]' \
             ;
           ;;
       esac
@@ -86,6 +87,9 @@ __generator_spec_nest1() {
           __generator_spec_nest1_nest2
           ;;
         help)
+          __generator_spec_nest1_help
+          ;;
+        -h)
           __generator_spec_nest1_help
           ;;
         *)
@@ -126,6 +130,8 @@ __generator_spec_nest1_nest2() {
             'baz[Description of baz]' \
             'foo-bar[Dashed command]' \
             'help[Describe subcommands or one specific subcommand]' \
+            '-h[Describe subcommands or one specific subcommand]' \
+            'b[Description of baz]' \
             ;
           ;;
       esac
@@ -136,10 +142,16 @@ __generator_spec_nest1_nest2() {
           __generator_spec_nest1_nest2_baz
           ;;
         foo-bar)
-          __generator_spec_nest1_nest2_foo_u_bar
+          __generator_spec_nest1_nest2_foo_bar
           ;;
         help)
           __generator_spec_nest1_nest2_help
+          ;;
+        -h)
+          __generator_spec_nest1_nest2_help
+          ;;
+        b)
+          __generator_spec_nest1_nest2_baz
           ;;
         *)
           # if does not match any subcommand
@@ -164,7 +176,7 @@ __generator_spec_nest1_nest2_baz() {
   esac
 }
 
-__generator_spec_nest1_nest2_foo_u_bar() {
+__generator_spec_nest1_nest2_foo_bar() {
   _arguments \
     '*: :->rest'
 

--- a/spec/thor/zsh_completion/generator_spec.zsh
+++ b/spec/thor/zsh_completion/generator_spec.zsh
@@ -124,6 +124,7 @@ __generator_spec_nest1_nest2() {
           _values \
             'subcommand' \
             'baz[Description of baz]' \
+            'foo-bar[Dashed command]' \
             'help[Describe subcommands or one specific subcommand]' \
             ;
           ;;
@@ -133,6 +134,9 @@ __generator_spec_nest1_nest2() {
       case $words[$DEPTH] in
         baz)
           __generator_spec_nest1_nest2_baz
+          ;;
+        foo-bar)
+          __generator_spec_nest1_nest2_foo_u_bar
           ;;
         help)
           __generator_spec_nest1_nest2_help
@@ -149,6 +153,18 @@ __generator_spec_nest1_nest2() {
 
 
 __generator_spec_nest1_nest2_baz() {
+  _arguments \
+    '*: :->rest'
+
+  case $state in
+    rest)
+      # complete rest arguments
+      _files
+      ;;
+  esac
+}
+
+__generator_spec_nest1_nest2_foo_u_bar() {
   _arguments \
     '*: :->rest'
 


### PR DESCRIPTION
Following thor generation is improved:

```ruby
    nest2 = Class.new(Thor) do
      desc "baz", "Description of baz"
      def baz
        p options
        puts "baz"
      end
      map 'b' => 'baz'

      desc "foo-bar", "Dashed command"
      def foo_bar
        p options
        puts "foo-bar"
      end
    end
```