### PR TITLE
Use braces when expanding arrays

### DIFF
--- a/lib/thor/zsh_completion/template/subcommand_function.erb
+++ b/lib/thor/zsh_completion/template/subcommand_function.erb
@@ -25,7 +25,7 @@
       esac
       ;;
     *)
-      case $words[$DEPTH] in
+      case ${words[$DEPTH]} in
         <%- subcommand[:subcommands].each do |subcommand| -%>
         <%= subcommand[:name] %>)
           <%= function_name %>_<%= subcommand[:name] %>

--- a/spec/thor/zsh_completion/generator_spec.zsh
+++ b/spec/thor/zsh_completion/generator_spec.zsh
@@ -23,7 +23,7 @@ __generator_spec() {
       esac
       ;;
     *)
-      case $words[$DEPTH] in
+      case ${words[$DEPTH]} in
         foo)
           __generator_spec_foo
           ;;
@@ -76,7 +76,7 @@ __generator_spec_nest1() {
       esac
       ;;
     *)
-      case $words[$DEPTH] in
+      case ${words[$DEPTH]} in
         bar)
           __generator_spec_nest1_bar
           ;;
@@ -129,7 +129,7 @@ __generator_spec_nest1_nest2() {
       esac
       ;;
     *)
-      case $words[$DEPTH] in
+      case ${words[$DEPTH]} in
         baz)
           __generator_spec_nest1_nest2_baz
           ;;


### PR DESCRIPTION
Fix the generation of zsh completion scripts to prevent [ShellCheck][1] warnings
around [using braces when expanding arrays][2].

Edit: Just for future reference, it's worth noting that ShellCheck [doesn't officially support zsh](https://github.com/koalaman/shellcheck/issues/809). I am very much _not_ a shell expert, so don't claim to know the differences between bash and zsh when it comes to the checks that ShellCheck performs, but I _think_ this change is still valid for zsh.

It might be worth instead adding the pragma to the generated file to tell ShellCheck not to run?

[1]: https://www.shellcheck.net/
[2]: https://github.com/koalaman/shellcheck/wiki/SC1087