### PR TITLE
Update hat-tip in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+### 0.1.10
+
+Misc
+
+- update hat-tip of 0.1.9 CHANGELOG.md entry
+
 ### 0.1.9
 
 Bugfixes
 
-- fix file mode to avoid LoadError on the gem installed by another user (reported by @belden)
+- fix file mode to avoid LoadError on the gem installed by another user (reported by @gisenberg)
 
 ### 0.1.8
 

--- a/lib/thor/zsh_completion/version.rb
+++ b/lib/thor/zsh_completion/version.rb
@@ -1,5 +1,5 @@
 class Thor
   module ZshCompletion
-    VERSION = "0.1.9".freeze
+    VERSION = "0.1.10".freeze
   end
 end


### PR DESCRIPTION
I don't want to claim any undue credit to tracking this error down to
the 0.1.8 release. Update the CHANGELOG to reflect that it was
@gisenberg who filed https://github.com/labocho/thor-zsh_completion/issues/7

Honestly this is sort of a joke PR which I don't expect to be merged
(much less have a new version bumped out!), but I probably wouldn't
have looked into this far enough to have tracked down @labocho's
project and to have filed the issue above. I'd already discovered that
0.1.5 worked fine for me and was inclined to just move on with my day.

Real credit to @gisenberg, who cared enough to dig into the bug and
file it.